### PR TITLE
PROJ: React App Generator v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,93 @@
 # generator-react-atomic
 Generate React components following the patterns of Atomic Design
+
+## Introduction
+[TODO]
+
+## Features
+[TODO]
+
+## Getting Started
+
+First, install Yeoman if you don't have it already: `npm install -g yo`
+
+Then install the generator: `npm install -g generator-react-atomic`
+
+Follow the prompts to establish your default settings and preferences.
+
+## Usage
+
+### Generating a CRA app with Redux
+`yo react-atomic:create-app`
+
+
+### Generating a new React component
+Our component generator is designed to work with the app generator. It also enforces the principles of
+atomic design, and each component should be categorized as one of the following -- atom, molecule, organism, template, or page.
+
+To generate a new component, run:
+`yo react-atomic:component`
+
+
+## File Structure
+When generating a new app with the `yo react-atomic:create-app` command, we create get the following file structure:
+
+```
+├── public
+├── src
+│	 ├── components
+│	 │   └── core
+│	 │	     └── atoms
+│	 │	     └── molecules
+│	 │	     └── organisms
+│	 │	     └── templates
+│	 │	     └── pages
+│	 │	     └── app
+│	 │	         └── App.jsx <-- top level app mounts here
+│	 │   └── anotherApp
+│	 │	     └── ...
+│	 ├── reducers  
+│	 │   └── anotherApp    <-- all reducers related to anotherApp go here
+│	 │   └── root          <-- root reducer which combines and exports all reducers
+│	 │   └── store.js      <-- creates the redux store-provider, binds thunk, and injects combined reducers from reducers/index.js
+│	 ├── actions  
+│	 │   └── anotherApp    <-- actions and constants related to anotherApp in here
+├── package.json
+```
+
+This is the structure assumed also by the component generator. By default all components will be generated in their respective element folder within `src/components/core` unless otherwise specified.
+
+Generally, we recommend creating a new folder within `components/` for each major section of your app. Components which are generic enough to be used globally in your app belong in `core/`.
+
+To update the default directory used by the component generator, run `yo react-atomic init`, and you will be prompted to update your generator settings.
+
+## Types of Components
+There are 5 atomic elements which we mirror components after. There are no strict rules, but here are a few guidelines for determining which atomic level to place your component in:
+
+| Element     | Styles Incl  | Connected    |Example Usage |
+| ------------|:------------:|:------------:|:------------:|
+| Atom        |    Yes       | No           | Button       |
+| Molecule    |    Yes       | No           | Search bar   |
+| Organism    |    Yes       | Yes          | Data table   |
+| Template    |    Yes       | No           |Two-column layout|
+| Page        |    Yes       | Yes          | Profile page |
+
+
+#### Atoms
+Atoms are the lowest level building blocks of the application. They are not composed of sub-components -- rather they are typically representative of a single HTML element, styled a certain way. Think buttons, inputs, text elements, etc. Atoms are also not connected to state as they should be reusable given a set of props.
+
+#### Molecules
+Molecules are built on top of atoms. They are fairly low level components as well, but may combine a few smaller elements to form a more useful component. For example, a search bar -- which combines an input element and a button -- would be a good use case for a molecule. Molecules are also not connected to state as they should be reusable given a set of props.
+
+#### Organisms
+Organisms are more complex in nature. They tend to combine several molecules together and require a data layer as well. These components are generated Redux-aware and are connected to state.
+
+#### Templates
+Templates are used primarily for layouts. They are typically skeletons to place other elements in certain positions. Think about a two column layout, or a grid system. These components are not connected to state and should be reusable given a set of props.
+
+#### Pages
+Pages are big sections of your app that typically contain several organisms. These are also connected to state, which may or may not be necessary depending on the use case. Pages are the highest level element and might often use templates to lay out organisms and molecules.
+
+
+## Testing
+[TODO]

--- a/generators/component/index.js
+++ b/generators/component/index.js
@@ -9,17 +9,16 @@ module.exports = Generator.extend( {
 
 
     return this.prompt([
-
       /*
        * Use functional wrappers for prompts so we can test them
        * And they can be composable within our other generators
        */
       // sets `answers.name`
-      prompts.components.componentName(),
+      prompts.component.componentName(),
       // set `answers.atomicType`
-      prompts.components.atomicType(),
+      prompts.component.atomicType(),
       // set `answers.directory`
-      prompts.components.targetDirectory(defaultDirectory)
+      prompts.component.targetDirectory(defaultDirectory)
 
     ]).then((answers) => {
       const componentName = answers.name;
@@ -28,7 +27,6 @@ module.exports = Generator.extend( {
       // Create directory for the component
       const directory = `${answers.directory}/${answers.atomicType}/${answers.name}`;
       mkdirp.sync(directory);
-
       // Copy over the jsx component file
       // Pages and organisms will have redux connected
       // Templates, molecules and atoms will not
@@ -50,10 +48,10 @@ module.exports = Generator.extend( {
         );
       }
 
-      // Copy over the scss file
+      // Copy over the css file
       this.fs.copyTpl(
-        this.templatePath('component.scss'),
-        this.destinationPath(`${directory}/${componentNameLower}.scss`)
+        this.templatePath('component.module.css'),
+        this.destinationPath(`${directory}/${componentNameLower}.module.css`)
       );
 
       // Copy over the index.js file

--- a/generators/component/templates/ConnectedComponent.jsx
+++ b/generators/component/templates/ConnectedComponent.jsx
@@ -4,7 +4,7 @@ import autobind from 'autobind-decorator';
 import CSSModules from 'react-css-modules';
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
-import styles from './<%= nameLower %>.scss';
+import styles from './<%= nameLower %>.module.css';
 
 class <%= name %> extends React.Component {
 
@@ -48,8 +48,5 @@ function mapDispatchToProps(dispatch) {
 
 export {<%= name %>};
 
-const styledComponent = CSSModules(<%= name %>, styles);
-export {styledComponent as styledComponent};
-
-const connectedComponent = connect(mapStateToProps, mapDispatchToProps)(styledComponent);
+const connectedComponent = connect(mapStateToProps, mapDispatchToProps)(<%= name %>);
 export default connectedComponent;

--- a/generators/component/templates/PureRenderComponent.jsx
+++ b/generators/component/templates/PureRenderComponent.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import autobind from 'autobind-decorator';
 import CSSModules from 'react-css-modules';
-import styles from './<%= nameLower %>.scss';
+import styles from './<%= nameLower %>.module.css';
 
 class <%= name %> extends React.Component {
 
@@ -32,6 +32,4 @@ class <%= name %> extends React.Component {
 }
 
 
-export {<%= name %>};
-
-export default CSSModules(<%= name %>, styles);
+export default <%= name %>;

--- a/generators/create-app/index.js
+++ b/generators/create-app/index.js
@@ -1,39 +1,50 @@
 const Generator = require('yeoman-generator');
 const mkdirp = require('mkdirp');
+const prompts = require('../../libs/prompts');
 
 module.exports = Generator.extend( {
   create: function () {
-    return this.prompt([{
-      type    : 'input',
-      name    : 'name',
-      message : 'What is the name of your new app?'
-    }, {
-      type    : 'confirm',
-      name    : 'confirmation',
-      message : "Awesome. I'm going to create a directory here with a React app. Is that okay?"
-    }]).then((answers) => {
-      const confirmation = answers.confirmation;
-      // TODO: strip out punctuation and spaces from the name
-      const directory = answers.name;
+    return this.prompt([
+       /*
+       * Use functional wrappers for prompts so we can test them
+       * And they can be composable within our other generators
+       */
+      // sets `answers.name`
+      prompts.createApp.name(),
+      // set `answers.confirmation`
+      prompts.createApp.confirmation()
 
-      // Create directory for the component
-      mkdirp.sync(directory);
+      ]).then((answers) => {
+
+      const confirmation = answers.confirmation;
 
       // Generate the cra-redux template inside the newly created directory
       if (confirmation) {
+        const appName = answers.name;
+        // Strips out spaces and punctuation to create valid directory
+        const directory = appName.replace(/[^a-z0-9_\-]/gi, '');
+
+        // Create directory for the component
+        mkdirp.sync(directory);
         this.fs.copyTpl(
           this.templatePath('cra-redux'),
           this.destinationPath(`${directory}/`),
-          { name: answers.name
-          }
+          { name: appName } // Data passed to the templates
         );
+      } else {
+        process.exit()
       }
     });
   },
   install: function() {
-
+    //  Where installations are run (i.e. npm)
   },
   end: function() {
-    this.log("Your app is ready! Check out the instructions in the Readme on how to run the app. Enjoy :).")
+
+    this.log("\n");
+    this.log("Your app is ready! To get started, cd into your new app directory and run the commands below. Check out the Readme for more helpful tips.\n");
+    this.log(" $ npm install" + "\n");
+    this.log(" $ npm start" + "\n ");
+    this.log("You are all set. Enjoy! \n");
   }
 });

--- a/generators/create-app/index.js
+++ b/generators/create-app/index.js
@@ -1,0 +1,39 @@
+const Generator = require('yeoman-generator');
+const mkdirp = require('mkdirp');
+
+module.exports = Generator.extend( {
+  create: function () {
+    return this.prompt([{
+      type    : 'input',
+      name    : 'name',
+      message : 'What is the name of your new app?'
+    }, {
+      type    : 'confirm',
+      name    : 'confirmation',
+      message : "Awesome. I'm going to create a directory here with a React app. Is that okay?"
+    }]).then((answers) => {
+      const confirmation = answers.confirmation;
+      // TODO: strip out punctuation and spaces from the name
+      const directory = answers.name;
+
+      // Create directory for the component
+      mkdirp.sync(directory);
+
+      // Generate the cra-redux template inside the newly created directory
+      if (confirmation) {
+        this.fs.copyTpl(
+          this.templatePath('cra-redux'),
+          this.destinationPath(`${directory}/`),
+          { name: answers.name
+          }
+        );
+      }
+    });
+  },
+  install: function() {
+
+  },
+  end: function() {
+    this.log("Your app is ready! Check out the instructions in the Readme on how to run the app. Enjoy :).")
+  }
+});

--- a/generators/create-app/templates/cra-redux/README.md
+++ b/generators/create-app/templates/cra-redux/README.md
@@ -1,7 +1,68 @@
-# TODO
+# Atomic React App with Redux
 
-Things to include
-* What's included out of the box
-* Instructions on running the app
-* How to use with component generators
-* How it compares to CRA
+
+## Getting Started
+
+Install the dependencies:
+
+```
+npm install
+```
+
+Run the app:
+```
+npm start
+```
+
+## Components structure
+
+This app comes with a few boilerplate components located in the `src/components/core` directory.
+Within this directory, components are broken out into one of the following categories:
+
+### Atoms
+
+### Molecules
+
+### Organisms
+
+### Templates
+
+### Pages
+
+
+
+
+## Generating New Components
+To generate a new component, we recommend using the built in component generator. It reduces all the boiler plate work and generates all component files required in a standardized format.
+
+To generate a new component, simply run:
+```
+yo react-atomic:component
+```
+and answer the follow up questions about your component.
+
+A few guidelines for determining which atomic level to place your component in:
+
+| Element     | Styles Incl  | Connected    |Example Usage |
+| ------------|:------------:|:------------:|:------------:|
+| Atom        |    Yes       | No           | Button       |
+| Molecule    |    Yes       | No           | Search bar   |
+| Organism    |    Yes       | Yes          | Data table   |
+| Template    |    Yes       | No           |Two-column layout|
+| Page        |    Yes       | Yes          | Profile page |
+
+
+### Atoms
+Atoms are the lowest level building blocks of the application. They are not composed of sub-components -- rather they are typically representative of a single HTML element, styled a certain way. Think buttons, inputs, text elements, etc. Atoms are also not connected to state as they should be reusable given a set of props.
+
+### Molecules
+Molecules are built on top of atoms. They are fairly low level components as well, but may combine a few smaller elements to form a more useful component. For example, a search bar -- which combines an input element and a button -- would be a good use case for a molecule. Molecules are also not connected to state as they should be reusable given a set of props.
+
+### Organisms
+Organisms are more complex in nature. They tend to combine several molecules together and require a data layer as well. These components are generated Redux-aware and are connected to state.
+
+### Templates
+Templates are used primarily for layouts. They are typically skeletons to place other elements in certain positions. Think about a two column layout, or a grid system. These components are not connected to state and should be reusable given a set of props.
+
+### Pages
+Pages are big sections of your app that typically contain several organisms. These are also connected to state, which may or may not be necessary depending on the use case. Pages are the highest level element and might often use templates to lay out organisms and molecules.

--- a/generators/create-app/templates/cra-redux/README.md
+++ b/generators/create-app/templates/cra-redux/README.md
@@ -1,0 +1,7 @@
+# TODO
+
+Things to include
+* What's included out of the box
+* Instructions on running the app
+* How to use with component generators
+* How it compares to CRA

--- a/generators/create-app/templates/cra-redux/package.json
+++ b/generators/create-app/templates/cra-redux/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "<%= name %>",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "autobind-decorator": "^2.1.0",
+    "history": "^4.7.2",
+    "react": "^16.2.0",
+    "react-css-modules": "^4.7.1",
+    "react-dom": "^16.2.0",
+    "react-redux": "^5.0.6",
+    "react-router-dom": "^4.2.2",
+    "react-router-redux": "^5.0.0-alpha.9",
+    "react-scripts": "1.1.0",
+    "redux": "^3.7.2",
+    "redux-thunk": "^2.2.0"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  },
+  "standard": {
+    "parser": "babel-eslint"
+  }
+}

--- a/generators/create-app/templates/cra-redux/package.json
+++ b/generators/create-app/templates/cra-redux/package.json
@@ -11,7 +11,7 @@
     "react-redux": "^5.0.6",
     "react-router-dom": "^4.2.2",
     "react-router-redux": "^5.0.0-alpha.9",
-    "react-scripts": "2.0.0-next.47d2d941",
+    "react-scripts": "2.0.0-next.b2fd8db8",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0"
   },

--- a/generators/create-app/templates/cra-redux/package.json
+++ b/generators/create-app/templates/cra-redux/package.json
@@ -11,7 +11,7 @@
     "react-redux": "^5.0.6",
     "react-router-dom": "^4.2.2",
     "react-router-redux": "^5.0.0-alpha.9",
-    "react-scripts": "1.1.0",
+    "react-scripts": "2.0.0-next.47d2d941",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0"
   },

--- a/generators/create-app/templates/cra-redux/public/index.html
+++ b/generators/create-app/templates/cra-redux/public/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="theme-color" content="#000000">
+    <!--
+      manifest.json provides metadata used when your web app is added to the
+      homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
+    -->
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
+    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
+    <!--
+      Notice the use of %PUBLIC_URL% in the tags above.
+      It will be replaced with the URL of the `public` folder during the build.
+      Only files inside the `public` folder can be referenced from the HTML.
+
+      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      work correctly both with client-side routing and a non-root public URL.
+      Learn how to configure a non-root public URL by running `npm run build`.
+    -->
+    <title>React App</title>
+  </head>
+  <body>
+    <noscript>
+      You need to enable JavaScript to run this app.
+    </noscript>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
+  </body>
+</html>

--- a/generators/create-app/templates/cra-redux/public/index.html
+++ b/generators/create-app/templates/cra-redux/public/index.html
@@ -9,7 +9,6 @@
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
-    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
@@ -19,7 +18,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title><%= name %></title>
   </head>
   <body>
     <noscript>

--- a/generators/create-app/templates/cra-redux/src/components/core/app/App.jsx
+++ b/generators/create-app/templates/cra-redux/src/components/core/app/App.jsx
@@ -1,0 +1,26 @@
+import React, { Component } from 'react';
+import { Route, Link } from 'react-router-dom'
+import Home from '../pages/Home'
+import About from '../pages/About'
+
+/** This component gets mounted from the main index.js **/
+class App extends Component {
+  render() {
+    return (
+      <div>
+        <header>
+          <h1> Atomic React App </h1>
+          <Link to="/">Home</Link>
+          <Link to="/about">About</Link>
+        </header>
+        {/* Routes */}
+        <main>
+          <Route exact path="/" component={Home} />
+          <Route exact path="/about" component={About} />
+        </main>
+      </div>
+    );
+  }
+}
+
+export default App;

--- a/generators/create-app/templates/cra-redux/src/components/core/app/App.jsx
+++ b/generators/create-app/templates/cra-redux/src/components/core/app/App.jsx
@@ -2,16 +2,17 @@ import React, { Component } from 'react';
 import { Route, Link } from 'react-router-dom'
 import Home from '../pages/Home'
 import About from '../pages/About'
+import styles from './app.module.css'
 
 /** This component gets mounted from the main index.js **/
 class App extends Component {
   render() {
     return (
-      <div>
-        <header>
-          <h1> Atomic React App </h1>
-          <Link to="/">Home</Link>
-          <Link to="/about">About</Link>
+      <div className="app">
+        <header >
+          <h1 className={styles.header}> Atomic React App </h1>
+          <Link className={styles.navlink} to="/">Home</Link>
+          <Link className={styles.navlink} to="/about">About</Link>
         </header>
         {/* Routes */}
         <main>

--- a/generators/create-app/templates/cra-redux/src/components/core/app/App.test.js
+++ b/generators/create-app/templates/cra-redux/src/components/core/app/App.test.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(<App />, div);
+  ReactDOM.unmountComponentAtNode(div);
+});

--- a/generators/create-app/templates/cra-redux/src/components/core/app/app.module.css
+++ b/generators/create-app/templates/cra-redux/src/components/core/app/app.module.css
@@ -1,0 +1,13 @@
+.header {
+  color: #414C58;
+  letter-spacing: 1px;
+  font-family: sans-serif;
+  font-weight: 400;
+  text-align: center;
+}
+
+.navlink {
+  text-decoration: none;
+  color: #1f7ce8;
+  margin-right: 1rem;
+}

--- a/generators/create-app/templates/cra-redux/src/components/core/pages/About.jsx
+++ b/generators/create-app/templates/cra-redux/src/components/core/pages/About.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { push } from 'react-router-redux'
+import { bindActionCreators } from 'redux'
+import { connect } from 'react-redux'
+
+
+const About = props => (
+  <div>
+    <h1>About</h1>
+  </div>
+)
+
+const mapStateToProps = state => ({
+
+})
+
+const mapDispatchToProps = dispatch => bindActionCreators({
+
+}, dispatch)
+
+export default connect(mapStateToProps, mapDispatchToProps)(About)

--- a/generators/create-app/templates/cra-redux/src/components/core/pages/About.jsx
+++ b/generators/create-app/templates/cra-redux/src/components/core/pages/About.jsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux'
 
 const About = props => (
   <div>
-    <h1>About</h1>
+    <h1 className="page-title">About</h1>
   </div>
 )
 

--- a/generators/create-app/templates/cra-redux/src/components/core/pages/Home.jsx
+++ b/generators/create-app/templates/cra-redux/src/components/core/pages/Home.jsx
@@ -1,0 +1,43 @@
+import React, {Component, PropTypes} from 'react';
+import { push } from 'react-router-redux'
+import { bindActionCreators } from 'redux'
+import { connect } from 'react-redux'
+import autobind from 'autobind-decorator';
+import {
+  sampleAction
+} from '../../../reducers/sample/actions'
+
+class Home extends Component {
+
+  constructor(props) {
+    super(props);
+  }
+
+  sampleAction() {
+    this.props.dispatch.sampleAction()
+  }
+
+  render() {
+    return(
+      <div>
+        <h1 onClick={this.sampleAction.bind(this)}>Home</h1>
+        {this.props.sampleCount}
+      </div>
+    );
+  }
+
+}
+
+const mapStateToProps = state => ({
+  sampleCount: state.sample.sampleCount
+})
+
+const mapDispatchToProps = dispatch => {
+  return {
+    dispatch: bindActionCreators({
+      sampleAction
+    }, dispatch)
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Home)

--- a/generators/create-app/templates/cra-redux/src/components/core/pages/Home.jsx
+++ b/generators/create-app/templates/cra-redux/src/components/core/pages/Home.jsx
@@ -20,7 +20,7 @@ class Home extends Component {
   render() {
     return(
       <div>
-        <h1>Home</h1>
+        <h1 className="page-title">Home</h1>
         <span onClick={this.sampleAction.bind(this)}>
           Counter: {this.props.sampleCount}
         </span>

--- a/generators/create-app/templates/cra-redux/src/components/core/pages/Home.jsx
+++ b/generators/create-app/templates/cra-redux/src/components/core/pages/Home.jsx
@@ -20,8 +20,10 @@ class Home extends Component {
   render() {
     return(
       <div>
-        <h1 onClick={this.sampleAction.bind(this)}>Home</h1>
-        {this.props.sampleCount}
+        <h1>Home</h1>
+        <span onClick={this.sampleAction.bind(this)}>
+          Counter: {this.props.sampleCount}
+        </span>
       </div>
     );
   }

--- a/generators/create-app/templates/cra-redux/src/index.css
+++ b/generators/create-app/templates/cra-redux/src/index.css
@@ -1,0 +1,11 @@
+/* Global app styles */
+
+.app {
+  font-family: sans-serif;
+}
+
+.page-title {
+  font-size: 2rem;
+  font-weight: 400;
+  color: #414C58;
+}

--- a/generators/create-app/templates/cra-redux/src/index.js
+++ b/generators/create-app/templates/cra-redux/src/index.js
@@ -5,6 +5,7 @@ import { ConnectedRouter } from 'react-router-redux'
 import store, { history } from './reducers/store'
 import App from './components/core/app/App'
 import registerServiceWorker from './registerServiceWorker';
+import './index.css'
 
 const target = document.querySelector('#root')
 

--- a/generators/create-app/templates/cra-redux/src/index.js
+++ b/generators/create-app/templates/cra-redux/src/index.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render } from 'react-dom'
+import { Provider } from 'react-redux'
+import { ConnectedRouter } from 'react-router-redux'
+import store, { history } from './reducers/store'
+import App from './components/core/app/App'
+import registerServiceWorker from './registerServiceWorker';
+
+const target = document.querySelector('#root')
+
+render(
+  <Provider store={store}>
+    <ConnectedRouter history={history}>
+      <div>
+        <App />
+      </div>
+    </ConnectedRouter>
+  </Provider>,
+  target
+)

--- a/generators/create-app/templates/cra-redux/src/reducers/root/index.js
+++ b/generators/create-app/templates/cra-redux/src/reducers/root/index.js
@@ -1,0 +1,8 @@
+import { combineReducers } from 'redux'
+import { routerReducer } from 'react-router-redux'
+import sampleReducer from '../sample/sampleReducer'
+
+export default combineReducers({
+  routing: routerReducer,
+  sample: sampleReducer
+})

--- a/generators/create-app/templates/cra-redux/src/reducers/sample/actions.js
+++ b/generators/create-app/templates/cra-redux/src/reducers/sample/actions.js
@@ -1,0 +1,11 @@
+import {
+  SAMPLE_ACTION
+} from './constants'
+
+export const sampleAction = () => {
+  return dispatch => {
+    dispatch({
+      type: SAMPLE_ACTION
+    })
+  }
+}

--- a/generators/create-app/templates/cra-redux/src/reducers/sample/constants.js
+++ b/generators/create-app/templates/cra-redux/src/reducers/sample/constants.js
@@ -1,0 +1,1 @@
+export const SAMPLE_ACTION = 'SAMPLE_ACTION';

--- a/generators/create-app/templates/cra-redux/src/reducers/sample/sampleReducer.js
+++ b/generators/create-app/templates/cra-redux/src/reducers/sample/sampleReducer.js
@@ -1,0 +1,21 @@
+import {
+  SAMPLE_ACTION
+} from './constants';
+
+const initialState = {
+  sampleCount: 0
+}
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+
+    case SAMPLE_ACTION:
+      return {
+        ...state,
+        sampleCount: state.sampleCount + 1
+      }
+
+    default:
+      return state
+  }
+}

--- a/generators/create-app/templates/cra-redux/src/reducers/store.js
+++ b/generators/create-app/templates/cra-redux/src/reducers/store.js
@@ -1,0 +1,35 @@
+import { createStore, applyMiddleware, compose } from 'redux'
+import { routerMiddleware } from 'react-router-redux'
+import thunk from 'redux-thunk'
+import createHistory from 'history/createBrowserHistory'
+import rootReducer from './root';
+
+export const history = createHistory()
+
+const initialState = {}
+const enhancers = []
+const middleware = [
+  thunk,
+  routerMiddleware(history)
+]
+
+if (process.env.NODE_ENV === 'development') {
+  const devToolsExtension = window.devToolsExtension
+
+  if (typeof devToolsExtension === 'function') {
+    enhancers.push(devToolsExtension())
+  }
+}
+
+const composedEnhancers = compose(
+  applyMiddleware(...middleware),
+  ...enhancers
+)
+
+const store = createStore(
+  rootReducer,
+  initialState,
+  composedEnhancers
+)
+
+export default store

--- a/generators/create-app/templates/cra-redux/src/registerServiceWorker.js
+++ b/generators/create-app/templates/cra-redux/src/registerServiceWorker.js
@@ -1,0 +1,117 @@
+// In production, we register a service worker to serve assets from local cache.
+
+// This lets the app load faster on subsequent visits in production, and gives
+// it offline capabilities. However, it also means that developers (and users)
+// will only see deployed updates on the "N+1" visit to a page, since previously
+// cached resources are updated in the background.
+
+// To learn more about the benefits of this model, read https://goo.gl/KwvDNy.
+// This link also includes instructions on opting out of this behavior.
+
+const isLocalhost = Boolean(
+  window.location.hostname === 'localhost' ||
+    // [::1] is the IPv6 localhost address.
+    window.location.hostname === '[::1]' ||
+    // 127.0.0.1/8 is considered localhost for IPv4.
+    window.location.hostname.match(
+      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
+    )
+);
+
+export default function register() {
+  if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+    // The URL constructor is available in all browsers that support SW.
+    const publicUrl = new URL(process.env.PUBLIC_URL, window.location);
+    if (publicUrl.origin !== window.location.origin) {
+      // Our service worker won't work if PUBLIC_URL is on a different origin
+      // from what our page is served on. This might happen if a CDN is used to
+      // serve assets; see https://github.com/facebookincubator/create-react-app/issues/2374
+      return;
+    }
+
+    window.addEventListener('load', () => {
+      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
+
+      if (isLocalhost) {
+        // This is running on localhost. Lets check if a service worker still exists or not.
+        checkValidServiceWorker(swUrl);
+
+        // Add some additional logging to localhost, pointing developers to the
+        // service worker/PWA documentation.
+        navigator.serviceWorker.ready.then(() => {
+          console.log(
+            'This web app is being served cache-first by a service ' +
+              'worker. To learn more, visit https://goo.gl/SC7cgQ'
+          );
+        });
+      } else {
+        // Is not local host. Just register service worker
+        registerValidSW(swUrl);
+      }
+    });
+  }
+}
+
+function registerValidSW(swUrl) {
+  navigator.serviceWorker
+    .register(swUrl)
+    .then(registration => {
+      registration.onupdatefound = () => {
+        const installingWorker = registration.installing;
+        installingWorker.onstatechange = () => {
+          if (installingWorker.state === 'installed') {
+            if (navigator.serviceWorker.controller) {
+              // At this point, the old content will have been purged and
+              // the fresh content will have been added to the cache.
+              // It's the perfect time to display a "New content is
+              // available; please refresh." message in your web app.
+              console.log('New content is available; please refresh.');
+            } else {
+              // At this point, everything has been precached.
+              // It's the perfect time to display a
+              // "Content is cached for offline use." message.
+              console.log('Content is cached for offline use.');
+            }
+          }
+        };
+      };
+    })
+    .catch(error => {
+      console.error('Error during service worker registration:', error);
+    });
+}
+
+function checkValidServiceWorker(swUrl) {
+  // Check if the service worker can be found. If it can't reload the page.
+  fetch(swUrl)
+    .then(response => {
+      // Ensure service worker exists, and that we really are getting a JS file.
+      if (
+        response.status === 404 ||
+        response.headers.get('content-type').indexOf('javascript') === -1
+      ) {
+        // No service worker found. Probably a different app. Reload the page.
+        navigator.serviceWorker.ready.then(registration => {
+          registration.unregister().then(() => {
+            window.location.reload();
+          });
+        });
+      } else {
+        // Service worker found. Proceed as normal.
+        registerValidSW(swUrl);
+      }
+    })
+    .catch(() => {
+      console.log(
+        'No internet connection found. App is running in offline mode.'
+      );
+    });
+}
+
+export function unregister() {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.ready.then(registration => {
+      registration.unregister();
+    });
+  }
+}

--- a/libs/prompts/component.js
+++ b/libs/prompts/component.js
@@ -47,11 +47,11 @@ const atomicType = () => {
  * Used to map a prompt to get the TargetDirect where the template generation will occur
  */
 const targetDirectory = function(targetDirectory) {
-  const defaultDirectory = (targetDirectory)? targetDirectory:'';
+  const defaultDirectory = (targetDirectory) ? targetDirectory : 'src/components/core';
   const obj = {
     type    : 'input',
     name    : 'directory',
-    message : 'What directory should we create this in?',
+    message : 'Which directory should we create this in?',
     default: defaultDirectory
   };
   return obj;

--- a/libs/prompts/create-app.js
+++ b/libs/prompts/create-app.js
@@ -1,0 +1,38 @@
+/*
+ * Create functional wrappers for our prompts so that they can be reused
+ * When action / redux, test prompts are added consider renaming or moving
+ */
+
+
+/*
+ *  Ask for the name of the app
+ */
+const name = () => {
+  const obj = {
+    type    : 'input',
+    name    : 'name',
+    message : 'What is the name of your new app?',
+    default:  'new-react-atomic-app'
+  }
+  return obj;
+};
+
+
+/*
+ * Get confirmation before generating all the app files
+ */
+const confirmation = () => {
+  const obj = {
+    type    : 'confirm',
+    name    : 'confirmation',
+    message : "Awesome. I'm going to create a directory here with a React app. Is that okay?"
+  }
+  return obj;
+};
+
+
+// ES5 Export
+module.exports = {
+  'name': name,
+  'confirmation': confirmation
+}

--- a/libs/prompts/index.js
+++ b/libs/prompts/index.js
@@ -1,10 +1,10 @@
 // Component/StyledComponent prompts
-const componentPrompts = require('./components');
-// createApp prompots
-//const createAppPrompts = require('./createApp');
+const componentPrompts = require('./component');
+// createApp prompts
+const createAppPrompts = require('./create-app');
 
 // ES5 Export
 module.exports = {
-  'components': componentPrompts,
-  //'createApp': createAppPrompts,
+  'component': componentPrompts,
+  'createApp': createAppPrompts,
 }


### PR DESCRIPTION
## Summary
Introducing our first React/Redux App Generator!  This generator is a version of Facebook's CRA (v1.1.4), which has been customized to our atomic principles and comes with Redux out of the box.

**How it works**
Run `yo react-atomic:create-app` and follow the prompts to name your name app. A new directory will be created where you run the command, based on the name of your app. Instructions are given in the CLI and readme for how to run the app. That's it!

**Behind the scenes**
We are basically rebuilding the files generated by facebook's create-react-app generator (v1.1.4) with some file structure modifications and additional features. These changes are also required in order for the components generated with our atomic generator to work seamlessly within the app.

**Features we include in addition to basic CRA:**
- Redux and sample reducer to model usage
- CSS Modules 
- autobind-decorator 

**Additional Notes**
I specifically avoided requiring use of yeoman's config in the create-app generator because it creates a .yo-rc file which will then conflict with the .yo-rc required for the component generator. It would be in a directory level above the other one, and would override it. A good thing to keep in mind in case we are tempted to go back down that route. For now, it's a good idea to avoid advanced config and if we need different versions, we should create a new app generator.

## Follow ups
- This app comes with CSS Modules -- how do styled components fit it? 
- After including styled components, we can also create a boilerplate theming system
- What about SASS? Do we support?
- npm install works, yarn currently does not 👍 
- Add in `reselect` for selectors
- Update the Home page to be more useful than its current 2 page system with the counter. Perhaps it is branded and describes our system of atomic generators (i.e. replaces readme?) 
- Further documentation on usage and atomic principles



